### PR TITLE
Calculate the run count from the database

### DIFF
--- a/public/components/run/attendance/attendance.stache
+++ b/public/components/run/attendance/attendance.stache
@@ -76,11 +76,7 @@
               {{runCount}}
             </td>
             <td class="text-center">
-              {{#if hareCountPromise.isPending}}
-                <span class="fa fa-circle-notch fa-spin"></span>
-              {{else}}
-                {{hareCount}}
-              {{/if}}
+              {{hareCount}}
             </td>
           </tr>
         {{/each}}

--- a/public/models/hasher.js
+++ b/public/models/hasher.js
@@ -150,35 +150,7 @@ const Hasher = DefineMap.extend({
   },
   givenName: 'string',
   givenNamePrivate: 'string',
-  hareCount: {
-    get: function(lastValue, setValue) {
-      if (lastValue) {
-        return lastValue;
-      }
-      const hareCountPromise = this.hareCountPromise;
-      if (hareCountPromise && setValue) {
-        hareCountPromise.then(result => {
-          setValue(result.total);
-        });
-      }
-    },
-    serialize: false
-  },
-  hareCountPromise: {
-    get: function() {
-      const hasherId = this.id;
-      if (hasherId) {
-        return EventsHashers.connection.getList({
-          $limit: 0,
-          hasherId,
-          role: {
-            $iLike: 'hare%'
-          }
-        });
-      }
-    },
-    serialize: false
-  },
+  hareCount: 'number',
   hasDied: {
     type: 'boolean',
     serialize: false,


### PR DESCRIPTION
The `runCount` is now overwritten with a count from the `events_hashers` table when `hashers` are fetched. This should make the run count more accurate.